### PR TITLE
Prevent input-output aliasing in function calls.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
     <Deterministic>true</Deterministic>
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <Product>Blech compiler</Product>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>2019-2020 see blech-lang.org</Copyright>

--- a/src/Intermediate/Causality.fs
+++ b/src/Intermediate/Causality.fs
@@ -336,7 +336,7 @@ let private addWRedges context name writtenVar logger =
                         let wrp1 = findNameRead ([],[]) r
                         let wrp2 = findNameWritten ([],[]) l
                         if List.contains writtenVar (fst wrp1) && List.contains writtenVar (snd wrp1)
-                           or List.contains writtenVar (fst wrp2) && List.contains writtenVar (snd wrp2) then
+                           || List.contains writtenVar (fst wrp2) && List.contains writtenVar (snd wrp2) then
                             Diagnostics.Logger.addDiagnostic
                                 logger 
                                 (mkDiagnosticAliasWRerror 

--- a/src/Intermediate/Causality.fs
+++ b/src/Intermediate/Causality.fs
@@ -262,9 +262,10 @@ let private addWRedges context name writtenVar logger =
             |> Seq.iter(fun (rangeInRN, readingNode) -> // check every reading node
                 if writingNode = readingNode then
                     match writingNode.Payload.Typ with
+                    | ActionLocation (FunctionCall _)
                     | CallNode _ ->
                         Diagnostics.Logger.addDiagnostic logger (mkDiagnosticAliasWRerror writtenVar (rangeInWN, writingNode) (rangeInRN, readingNode)) 
-                    | _ -> ()
+                    | _ -> () // we allow read and writing to the same memory in other nodes, e.g. assignment
                 elif areBothInSurfOrDepth pg.Graph writingNode readingNode then // areBothInSurfOrDepth includes areConcurrent check
                     pg.Graph.AddEdge (DataFlow (writtenVar, rangeInWN, rangeInRN)) writingNode readingNode // and in that case add a WR edge
                 else

--- a/src/Intermediate/Causality.fs
+++ b/src/Intermediate/Causality.fs
@@ -250,6 +250,73 @@ let private determineCycles pg =
     let pairs = GenericGraph.johnson75 cycleAnalysisGraph // decompose the resulting graph into cycles
     [for pair in pairs do yield (GenericGraph.mergeMappings mapping (fst pair), snd pair)]
 
+open Blech.Frontend.BlechTypes
+// C&P from ProgramGraph.fs with modifications
+let rec internal findNameWritten wrPair (tlhs: TypedLhs) =
+    let newWrPair (tml: TypedMemLoc) =
+        tml.FindAllIndexExpr 
+        |> List.fold findNameRead wrPair
+    match tlhs.lhs with
+    | Wildcard -> wrPair
+    | LhsCur tml ->
+        let wrp1 = newWrPair tml 
+        ((Cur tml) :: fst wrp1, snd wrp1)
+    | LhsNext tml ->
+        let wrp1 = newWrPair tml 
+        ((Next tml) :: fst wrp1, snd wrp1)
+
+and internal findNameRead wrPair trhs =
+    let processFields fields =
+        fields
+        |> List.unzip
+        |> snd // here we get a list of all rhs expr used in this literal
+        |> List.fold findNameRead wrPair
+
+    match trhs.rhs with
+    | RhsCur tml -> 
+        // check for array index expressions and recursively call addNameRead on them
+        let newWrPair =
+            tml.FindAllIndexExpr 
+            |> List.fold findNameRead wrPair
+        (fst newWrPair, (Cur tml) :: snd newWrPair)
+    | Prev _ -> wrPair // this is irrelevant for causality
+    | FunCall (name, ins, outs) ->
+        // add local names for this call
+        let wrp1 = ins |> List.fold findNameRead wrPair
+        outs |> List.fold findNameWritten wrp1 
+    | BoolConst _ 
+    | IntConst _
+    | BitsConst _
+    | NatConst _
+    | FloatConst _ 
+    | ResetConst _ -> wrPair
+    | StructConst structFieldExprList ->
+        structFieldExprList |> processFields
+    | ArrayConst elems ->
+        elems |> processFields
+    | Convert (expr, _, _)
+    | Bnot expr
+    | Neg expr -> findNameRead wrPair expr
+    | Conj (ex1, ex2)
+    | Disj (ex1, ex2)
+    | Band (ex1, ex2)
+    | Bor (ex1, ex2)
+    | Bxor (ex1, ex2)
+    | Shl (ex1, ex2)
+    | Shr (ex1, ex2)
+    | Sshr (ex1, ex2)
+    | Rotl (ex1, ex2)
+    | Rotr (ex1, ex2)
+    | Les (ex1, ex2)
+    | Leq (ex1, ex2)
+    | Equ (ex1, ex2)
+    | Add (ex1, ex2)
+    | Sub (ex1, ex2)
+    | Mul (ex1, ex2)
+    | Div (ex1, ex2)
+    | Mod (ex1, ex2) ->
+        findNameRead wrPair ex1
+        |> findNameRead <| ex2
 
 let private addWRedges context name writtenVar logger =
     try
@@ -262,11 +329,32 @@ let private addWRedges context name writtenVar logger =
             |> Seq.iter(fun (rangeInRN, readingNode) -> // check every reading node
                 if writingNode = readingNode then
                     match writingNode.Payload.Typ with
-                    | ActionLocation (FunctionCall _)
-                    | CallNode _ ->
-                        Diagnostics.Logger.addDiagnostic logger (mkDiagnosticAliasWRerror writtenVar (rangeInWN, writingNode) (rangeInRN, readingNode)) 
-                    | _ -> () // we allow read and writing to the same memory in other nodes, e.g. assignment
-                elif areBothInSurfOrDepth pg.Graph writingNode readingNode then // areBothInSurfOrDepth includes areConcurrent check
+                    // it is OK if the node is an assignment where the
+                    // lhs only writes "name", and
+                    // rhs only reads "name"
+                    | ActionLocation (Action.Assign (_, l, r)) ->
+                        let wrp1 = findNameRead ([],[]) r
+                        let wrp2 = findNameWritten ([],[]) l
+                        if List.contains writtenVar (fst wrp1) && List.contains writtenVar (snd wrp1)
+                           or List.contains writtenVar (fst wrp2) && List.contains writtenVar (snd wrp2) then
+                            Diagnostics.Logger.addDiagnostic
+                                logger 
+                                (mkDiagnosticAliasWRerror 
+                                    writtenVar 
+                                    (rangeInWN, writingNode) 
+                                    (rangeInRN, readingNode)
+                                )
+                        else ()
+                    // otherwise this is an aliasing error
+                    | _ ->
+                        Diagnostics.Logger.addDiagnostic
+                            logger 
+                            (mkDiagnosticAliasWRerror 
+                                writtenVar 
+                                (rangeInWN, writingNode) 
+                                (rangeInRN, readingNode)
+                            ) 
+                elif areBothInSurfOrDepth pg.Graph writingNode readingNode then
                     pg.Graph.AddEdge (DataFlow (writtenVar, rangeInWN, rangeInRN)) writingNode readingNode // and in that case add a WR edge
                 else
                     ()

--- a/test/TestPhases/causality/invalid/functionInputOutputAliasing.blc
+++ b/test/TestPhases/causality/invalid/functionInputOutputAliasing.blc
@@ -1,0 +1,24 @@
+struct S
+    var i: int32
+end
+
+function g(s: S)(t: S)
+    t.i = 2
+    t.i = s.i + t.i
+end
+
+function f(x: int32)(y: int32)
+    y = 2
+    y = x + y
+end
+
+@[EntryPoint]
+activity A()()
+    var a: S = {i = 17}
+    g(a)(a) // before fix: a.i == 4
+
+    var b: int32 = 17
+    f(b)(b) // before fix: b == 19
+
+    await true
+end

--- a/test/TestPhases/causality/invalid/functionInputOutputAliasing2.blc
+++ b/test/TestPhases/causality/invalid/functionInputOutputAliasing2.blc
@@ -1,0 +1,14 @@
+function f(x: int32)(y: int32) returns int32
+    y = 2
+    y = x + y
+    return y
+end
+
+@[EntryPoint]
+activity A()() returns int32
+    var b: int32 = 17
+    var x = f(b)(b) // VarDecl
+    
+    await true
+    return 0
+end 

--- a/test/TestPhases/causality/invalid/functionInputOutputAliasing3.blc
+++ b/test/TestPhases/causality/invalid/functionInputOutputAliasing3.blc
@@ -1,0 +1,14 @@
+function f(x: int32)(y: int32) returns int32
+    y = 2
+    y = x + y
+    return y
+end
+
+@[EntryPoint]
+activity A()() returns int32
+    var b: int32 = 17
+    var x = 0:int32
+    x = f(b)(b) // assignment, rhs issue
+    await true
+    return 0
+end 

--- a/test/TestPhases/causality/invalid/functionInputOutputAliasing4.blc
+++ b/test/TestPhases/causality/invalid/functionInputOutputAliasing4.blc
@@ -1,0 +1,14 @@
+function f(x: int32)(y: int32) returns int32
+    y = 2
+    y = x + y
+    return y
+end
+
+@[EntryPoint]
+activity A()() returns int32
+    var b: int32 = 17
+    await true
+    var a: [20]int32
+    a[f(b)(b)] = 8 // assignment, lhs issue
+    return 0
+end 

--- a/test/TestPhases/causality/invalid/functionInputOutputAliasing5.blc
+++ b/test/TestPhases/causality/invalid/functionInputOutputAliasing5.blc
@@ -1,0 +1,12 @@
+function f(x: int32)(y: int32) returns int32
+    y = 2
+    y = x + y
+    return y
+end
+
+@[EntryPoint]
+activity A()() returns int32
+    var b: int32 = 17
+    await true
+    return f(b)(b) // return
+end 

--- a/test/blechc/codegeneration/uint.blc
+++ b/test/blechc/codegeneration/uint.blc
@@ -15,7 +15,8 @@ activity R (input: nat64)(out: nat8) returns nat32
     repeat
         out = out + 1
         await true
-        f(g(input, out))(out)
+        let prevout = out
+        f(g(input, prevout))(out)
     end
     return 17
 end

--- a/test/blechc/codegeneration/uint.spec.json
+++ b/test/blechc/codegeneration/uint.spec.json
@@ -7,9 +7,10 @@
 				"pc_4_R_pc_3" : 0
 			},
 			"vars": {
-				"u8_line26" : 0,
-				"u16_line27" : 0,
-				"retcode_line28" : 0
+				"u8_line27" : 0,
+				"u16_line28" : 0,
+				"retcode_line29" : 0,
+				"prevout_line18" : 0
 			}
 		},
 		{
@@ -19,9 +20,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 130,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 130,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 0
 			}
 		},
 		{
@@ -31,9 +33,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 130
 			}
 		},
 		{
@@ -43,9 +46,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -55,9 +59,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -67,9 +72,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -79,9 +85,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -91,9 +98,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -103,9 +111,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -115,9 +124,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -127,9 +137,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -139,9 +150,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -151,9 +163,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -163,9 +176,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -175,9 +189,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -187,9 +202,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -199,9 +215,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -211,9 +228,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -223,9 +241,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -235,9 +254,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -247,9 +267,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -259,9 +280,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -271,9 +293,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -283,9 +306,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -295,9 +319,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -307,9 +332,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -319,9 +345,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -331,9 +358,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -343,9 +371,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -355,9 +384,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -367,9 +397,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -379,9 +410,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -391,9 +423,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -403,9 +436,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -415,9 +449,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -427,9 +462,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -439,9 +475,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -451,9 +488,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -463,9 +501,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -475,9 +514,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -487,9 +527,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -499,9 +540,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -511,9 +553,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -523,9 +566,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -535,9 +579,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -547,9 +592,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -559,9 +605,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -571,9 +618,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -583,9 +631,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -595,9 +644,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -607,9 +657,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -619,9 +670,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -631,9 +683,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -643,9 +696,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -655,9 +709,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -667,9 +722,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -679,9 +735,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -691,9 +748,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -703,9 +761,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		},
 		{
@@ -715,9 +774,10 @@
 				"pc_4_R_pc_3" : 4
 			},
 			"vars": {
-				"u8_line26" : 7,
-				"u16_line27" : 384,
-				"retcode_line28" : 0
+				"u8_line27" : 7,
+				"u16_line28" : 384,
+				"retcode_line29" : 0,
+				"prevout_line18" : 7
 			}
 		}
 	]


### PR DESCRIPTION
Following up a recent discussion this fix prevents aliasing arguments in function calls.
Regardless of possible future extensions to the language a la borrowing and such, in its current state this is a bug fix.
The unit test causality/invalid/functionInputOutputAliasing.blc demonstrates this.
Only one previous test is affected and fixed: codegeneration/uint.blc - note how the observable behaviour is still exactly the same at the cost of one more variable.