### PR TITLE
Fix -Wunused-but-set-variable for activity calls

### DIFF
--- a/src/Backend/CPdataAccess2.fs
+++ b/src/Backend/CPdataAccess2.fs
@@ -884,7 +884,7 @@ let cpActivityCall tcc pcName whoToCall inputs outputs receiverVar termRetcodeVa
             renderedRetvarOpt |> Option.toList |> List.collect getPrereq 
         ]
         |> List.concat
-    let actCallStmt = (cpName (Some Current) tcc termRetcodeVarName).Render <+> txt "=" <+> actCall <^> semi
+    let actCallStmt = (renderCName Current tcc termRetcodeVarName) <+> txt "=" <+> actCall <^> semi
     mkRenderedStmt prereqStmts actCallStmt
 
 

--- a/src/blechc/include/blech.h
+++ b/src/blechc/include/blech.h
@@ -95,4 +95,9 @@ typedef BLC_PC_T blc_pc_t;
 #define BLC_F32(f) (blc_float32)f
 #define BLC_F64(f) (blc_float64)f
 
+/*
+ * Using a void cast, explicitly mark a variable as unused
+ */
+#define BLC_UNUSED(v) ((void) v)
+
 #endif


### PR DESCRIPTION
when calling an activity the first time, mark the return-code variable as unused

Signed-off-by: Friedrich.Gretz <Friedrich.Gretz@de.bosch.com>