### PR TITLE
Removed tmp variable for returned compound literal

### DIFF
--- a/src/Frontend/BlechTypes.fs
+++ b/src/Frontend/BlechTypes.fs
@@ -626,6 +626,11 @@ and RhsStructure =
 
     member this.ToDoc = this.ppExpr dpPrec.["min"]
 
+    member this.IsCompoundConst =
+        match this with
+        | ResetConst | StructConst _ | ArrayConst _ -> true
+        | _ -> false
+
     member this.GetIntConst: Int =
         match this with
         | IntConst i -> i


### PR DESCRIPTION
Removed memset if init value or returned value is not
literal - that means the result of a function call.
Still to factor out some code duplication
in function translator and activity translator
for variable declarations and return statements.

Signed-off-by: Franz-Josef Grosch <schorg@gmail.com>