### PR TITLE
Update CONTRIBUTING to use the standard DCO 1.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,48 +18,58 @@ copyright holders.
 
 ## Sign your work
 
-This project tracks patch provenance and licensing using a modified Developer
-Certificate of Origin (DCO; from [OSDL][DCO]) and Signed-off-by tags initially
-developed by the Linux kernel project.
+his project tracks patch provenance and licensing using the Developer
+Certificate of Origin 1.1 (DCO) from [developercertificate.org][DCO] and
+Signed-off-by tags initially developed by the Linux kernel project.
 
-```
-Blech Developer's Certificate of Origin.  Version 1.0
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
 (a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the "Apache License, Version 2.0"
-    ("Apache-2.0"); or
+    have the right to submit it under the open source license
+    indicated in the file; or
 
-(b) The contribution is based upon previous work that is covered by
-    an appropriate open source license and I have the right under
-    that license to submit that work with modifications, whether
-    created in whole or in part by me, under the Apache-2.0 license;
-    or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
 
 (c) The contribution was provided directly to me by some other
-    person who certified (a) or (b) and I have not modified it.
+    person who certified (a), (b) or (c) and I have not modified
+    it.
 
 (d) I understand and agree that this project and the contribution
     are public and that a record of the contribution (including all
-    metadata and personal information I submit with it, including my
-    sign-off) is maintained indefinitely and may be redistributed
-    consistent with this project and the requirements of the Apache-2.0
-    license or any open source license(s) involved, where they are
-    relevant.
-
-(e) I am granting the contribution to this project under the terms of
-    Apache-2.0.
-
-    http://www.apache.org/licenses/LICENSE-2.0
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
 ```
 
 With the sign-off in a commit message you certify that you authored the patch
 or otherwise have the right to submit it under an open source license. The
-procedure is simple: To certify above Blech Developer's Certificate of
-Origin 1.0 for your contribution just append a line
+procedure is simple: To certify above Developer's Certificate of
+Origin 1.1 for your contribution just append a line
 
+```text
     Signed-off-by: Random J Developer <random@developer.example.org>
+```
 
 to every commit message using your real name or your pseudonym and a valid
 email address.
@@ -101,7 +111,6 @@ contribution was provided directly to me by some other person who certified
 (a) or (b) and I have not modified it", please add the appropriate copyright
 holder(s) to the [NOTICE](NOTICE) file as part of your contribution.
 
-
-[DCO]: http://web.archive.org/web/20070306195036/http://osdlab.org/newsroom/press_releases/2004/2004_05_24_dco.html
+[DCO]: https://developercertificate.org/
 
 [SubmittingPatches]: https://github.com/wking/signed-off-by/blob/7d71be37194df05c349157a2161c7534feaf86a4/Documentation/SubmittingPatches


### PR DESCRIPTION
Update the contributing guide to switch to the standard Developer's
Certificate of Origin 1.1

